### PR TITLE
Minimally invasive pom, integrates with existing project structure. S…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,108 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ca.mcgill.cs.swevo</groupId>
+    <artifactId>minesweeper</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0</version>
+    <name>Minesweeper</name>
+    <url>https://github.com/prmr/Minesweeper</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
+        <java.version>23</java.version>
+        <javafx.version>24.0.2</javafx.version>
+        <javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
+
+        <!-- Override default location of maven source and test classes, so the match standard java project structure.-->
+        <src.dir>src</src.dir>
+        <testsrc.dir>test</testsrc.dir>
+    </properties>
+
+    <!-- legal -->
+    <licenses>
+        <license>
+            <name>GPL-3</name>
+            <url>https://github.com/prmr/Minesweeper/blob/master/LICENSE</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <!--Two dependencies for JavaFx-->
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-swing</artifactId>
+            <version>24.0.2</version>
+        </dependency>
+
+        <!-- Dependency for testing with JUnit 5-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>6.0.0-M2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <!-- Override default name of generated jars -->
+        <finalName>Minesweeper</finalName>
+
+        <!-- Override source location (default for maven is src/main/java)-->
+        <!-- This is needed to preserve the option to build this project without maven. It advises maven to search
+        sources and test classes exactly where they are in a standard java project -->
+        <sourceDirectory>${src.dir}</sourceDirectory>
+        <testSourceDirectory>${testsrc.dir}</testSourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+
+            <!-- The javafx maven plugin has two executions (think of it like a lever that allows to toggle between standard launch and debugging.-->
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>${javafx.maven.plugin.version}</version>
+
+                <!--  To run (without debugger), use: mvn clean javafx:run@run-->
+                <executions>
+                    <execution>
+                        <id>run</id>
+                        <configuration>
+                            <mainClass>minesweeper/ca.mcgill.cs.swevo.minesweeper.Minesweeper</mainClass>
+                        </configuration>
+                    </execution>
+
+                    <!-- To run (without debugger), use: mvn clean javafx:run@debug -->
+                    <!-- You then need to attach a remote debugger -->
+                    <!-- See: https://stackoverflow.com/a/61341407/13805480-->
+                    <execution>
+                        <id>debug</id>
+                        <configuration>
+                            <mainClass>minesweeper/ca.mcgill.cs.swevo.minesweeper.Minesweeper</mainClass>
+                            <options>
+                                <option>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:8000</option>
+                            </options>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Minimally invasive pom, integrates with existing project structure. Supports building thin JAR with maven at package phase. JAR can be run after JavaFX/modules are manually placed on classpath.
Configuration supports direct run and debugging with maven.

Build commands:
 * `mvn clean package` created thin JAR.
 * After download of [JavaFX](https://jdk.java.net/javafx21/), JAR in `/target/Minesweeper.jar` can be run with:  
 `java --module-path /tmp/javafx-sdk-21.0.2/lib --add-modules javafx.controls,javafx.fxml -cp "/tmp/javafx/lib/*:target/Minesweeper.jar" ca.mcgill.cs.swevo.minesweeper.Minesweeper`
 
  > Note: `/tmp` must be adapted, based on where you extracted the downloaded JavaFX library.
  
  Run commands:
  
  * `mvn javafx:run@run` starts minesweeper.
  * `mvn javafx:run@debug` starts minesweeper and blocks startup until IDE debugger is attached on port 8000.