### PR TITLE
Added automatic checkstyle verification

### DIFF
--- a/config/Style.xml
+++ b/config/Style.xml
@@ -114,10 +114,10 @@
       <property name="severity" value="ignore"/>
       <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
     </module>
-    <module name="GenericIllegalRegexp">
-      <property name="severity" value="ignore"/>
-      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
-    </module>
+<!--    <module name="GenericIllegalRegexp">-->
+<!--      <property name="severity" value="ignore"/>-->
+<!--      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>-->
+<!--    </module>-->
     <module name="TodoComment">
       <property name="severity" value="ignore"/>
       <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
@@ -153,7 +153,7 @@
     <module name="UnnecessaryParentheses"/>
     <module name="BooleanExpressionComplexity"/>
     <module name="NPathComplexity"/>
-    <module name="PackageHtml">
+    <module name="MissingJavadocPackage">
       <property name="severity" value="ignore"/>
       <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
     </module>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,32 @@
                 </configuration>
             </plugin>
 
+            <!-- Enforces respecting checkstyle as part of validate phase (pre compile)-->
+            <!-- The validate phase will fail, cancelling the build, unless checkstyle is -->
+            <!-- respected in all classes -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <configLocation>config/Style.xml</configLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <violationSeverity>warning</violationSeverity>
+                    <failOnViolation>true</failOnViolation>
+                    <failsOnError>true</failsOnError>
+                    <linkXRef>false</linkXRef>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- The shade plugin is needed to create a "self-contained / fat" jar, that is,
             a jar with all dependencies included.-->
             <!-- Note, by default we want a thin jar, therefore this plugin has a "skip"


### PR DESCRIPTION
Addresses issue #7 

Added automatic checkstyle verification at validate phase, i.e. code not formatted based on Style.xml is rejected by build. Note: One deprecated checkstyle module updated, one deprecated commented out. [`PackageHtml` and `GenericIllegalRegexp`, see JetUML issue #509](https://github.com/prmr/JetUML/issues/509)

More precisely:

```xml
<module name="PackageHtml">
    <property name="severity" value="ignore"/>
    <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
</module>
```

replaced by:

```xml
<module name="MissingJavadocPackage">
      <property name="severity" value="ignore"/>
      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
</module>
```

And the following deprecated module removed (commented out):

```xml
    <module name="GenericIllegalRegexp">
      <property name="severity" value="ignore"/>
      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
    </module>
```

Tested, looks good. Code with .e.g `{` placed at end of line is rejected by maven, pointing to issue (`mvn clean validate`).