### PR TITLE
Issue 1 maven project java doc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,8 @@
                 <version>3.11.2</version>
                 <configuration>
                     <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+                    <!-- configure to produce HTML javadocs in target/docs -->
+                    <outputDirectory>${project.build.directory}/docs</outputDirectory>
                     <failOnWarnings>false</failOnWarnings>
                     <quiet>true</quiet>
                     <!-- Custom JavaDoc rule for @pre tag. -->

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,35 @@
                 </configuration>
             </plugin>
 
+            <!-- Plugin to ensure all functions are commented and generates html javadoc (in target dir) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.11.2</version>
+                <configuration>
+                    <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+                    <failOnWarnings>false</failOnWarnings>
+                    <quiet>true</quiet>
+                    <!-- Custom JavaDoc rule for @pre tag. -->
+                    <tags>
+                        <tag>
+                            <name>pre</name>
+                            <placement>a</placement>
+                            <head>Precondition:</head>
+                        </tag>
+                    </tags>
+                </configuration>
+                <!-- Execute this plugin as part of package phase -->
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- The shade plugin is needed to create a "self-contained / fat" jar, that is,
             a jar with all dependencies included.-->
             <!-- Note, by default we want a thin jar, therefore this plugin has a "skip"

--- a/src/ca/mcgill/cs/swevo/minesweeper/Cell.java
+++ b/src/ca/mcgill/cs/swevo/minesweeper/Cell.java
@@ -57,6 +57,7 @@ public class Cell
 	public Cell() {}
 	
 	/**
+	 * Getter to look up cell's hidden / not hidden status.
 	 * @return True if the cell is hidden, whether it is marked or not.
 	 */
 	public boolean isHidden() 
@@ -65,6 +66,7 @@ public class Cell
 	}
 	
 	/**
+	 * Getter to look up cell's marked / not marked status.
 	 * @return True if the cell is marked.
 	 */
 	public boolean isMarked()
@@ -73,6 +75,7 @@ public class Cell
 	}
 	
 	/**
+	 * Getter to look up if cell is mined.
 	 * @return True if the cell is mined, false otherwise.
 	 */
 	public boolean isMined() 

--- a/src/ca/mcgill/cs/swevo/minesweeper/Minefield.java
+++ b/src/ca/mcgill/cs/swevo/minesweeper/Minefield.java
@@ -51,6 +51,8 @@ public class Minefield
 	}
 	
 	/**
+	 * Getter for an all-positions iterator.
+	 *
 	 * @return An iterator over all positions in the mine field.
 	 */
 	public Iterable<Position> getAllPositions()
@@ -59,6 +61,8 @@ public class Minefield
 	}
 	
 	/**
+	 * Getter to look up MinefieldStatus of this field.
+	 *
 	 * @return A description of the current status of the mine field.
 	 */
 	public MinefieldStatus getStatus()
@@ -125,6 +129,8 @@ public class Minefield
 	}
 	
 	/**
+	 * Getter to look up if cell at a given position has already been revealed.
+	 *
 	 * @param pPosition The position to query.
 	 * @return True if the cell at pPosition is revealed.
 	 * @pre pPosition != null
@@ -136,6 +142,8 @@ public class Minefield
 	}
 	
 	/**
+	 * Getter to look up if cell at a given position has already been marked.
+	 *
 	 * @param pPosition The position to query.
 	 * @return True if the cell at pPosition is marked.
 	 * @pre pPosition != null
@@ -147,6 +155,8 @@ public class Minefield
 	}
 	
 	/**
+	 * Getter to look up if cell at a provided position is mined.
+	 *
 	 * @param pPosition The position to query.
 	 * @return True if the cell at pPosition is mined.
 	 * @pre pPosition != null

--- a/src/ca/mcgill/cs/swevo/minesweeper/Minefield.java
+++ b/src/ca/mcgill/cs/swevo/minesweeper/Minefield.java
@@ -40,7 +40,7 @@ public class Minefield
 	 * @param pRows The number of rows in the field.
 	 * @param pColumns The number of columns in the field.
 	 * @param pMines the number of mines in the field.
-	 * @pre pRows > 0 && pColumns > 0 && pMines >= 0 && pMines <= pColumns * pRows;
+	 * @pre pRows &gt; 0 &amp;&amp; pColumns > 0 &amp;&amp; pMines &gt;= 0 &amp;&amp; pMines &lt;= pColumns * pRows;
 	 */
 	public Minefield(int pRows, int pColumns, int pMines)
 	{

--- a/src/ca/mcgill/cs/swevo/minesweeper/Position.java
+++ b/src/ca/mcgill/cs/swevo/minesweeper/Position.java
@@ -35,7 +35,7 @@ public class Position
 	 * 
 	 * @param pRow The zero-indexed row of this position.
 	 * @param pColumn The zero-index column of this position.
-	 * @pre pRow >= 0 && pColumn >= 0;
+	 * @pre pRow >= 0 &amp;&amp; pColumn >= 0;
 	 */
 	public Position(int pRow, int pColumn)
 	{

--- a/src/ca/mcgill/cs/swevo/minesweeper/Position.java
+++ b/src/ca/mcgill/cs/swevo/minesweeper/Position.java
@@ -45,6 +45,8 @@ public class Position
 	}
 	
 	/**
+	 * Getter to look up row of this position object.
+	 *
 	 * @return The row index of this position.
 	 */
 	public int getRow()
@@ -53,6 +55,8 @@ public class Position
 	}
 	
 	/**
+	 * Getter to look up column of this position object.
+	 *
 	 * @return The column index of this position.
 	 */
 	public int getColumn()

--- a/src/module-info.java
+++ b/src/module-info.java
@@ -1,3 +1,6 @@
+/**
+ * Main javafx module for the minesweeper application.
+ */
 module minesweeper {
 	requires javafx.controls;
 	requires transitive javafx.graphics;	


### PR DESCRIPTION
Addresses issue #8 

Changes:

 * Added JavaDoc plugin to `pom.xml`.
   * The plugin verifies if all public methods showcase a correct JavaDoc (fails build if at least one element missing)
   * The plugin then transforms the JavaDocs to HTML, and places the webpages in `target/docs`
   * The plugin has been modified with a custom rule to convert custom `@pre` annotation to HTML.
 * Added additional JavaDocs / modified existing JavaDoc to comply.
   * `module-info` now has a JavaDoc descriptor.
   * All public methods in `src` now have an initial descriptor (getters were missing descriptor).
   * Restricted characters in pre clauses (ampersand) have been replaced by HTML escape code.