### PR TITLE
Fix shade plugin warnings on console and stop creation of fused pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,10 @@
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.0</version>
+                <configuration>
+                    <!-- stop spamming the base project with a fused pom -->
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,22 @@
                 <configuration>
                     <!-- stop spamming the base project with a fused pom -->
                     <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <!-- stop fusing meta files colliding from inner jars when creating far jar -->
+                    <!-- (not needed for project and silences warnings -->
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>module-info.class</exclude>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                                <exclude>META-INF/**/*.json</exclude>
+                                <exclude>META-INF/*.MF</exclude>
+                                <exclude>META-INF/substrate/config/resourcebundles</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
# Improvements for shade plugin configuration

## Silence warnings for conflicting files when creating fat jar

* When creating a fat Jar, the shade plugin currently encounters conflicts of project files and files included in project dependencies, e.g META-INF files. By default shade attempts fusing the files, which causes warning on console.
* Fusing is not needed, shade can be configured to exclude conflicting files.

## Stop writing fused pom to project root

* Shade creates a temporary file with fused dependencies when creating the fat jar.
* By default the file is stored outside the target directory, i.e. clutters the repo.
* The file is not needed after building, shade can be safely configured to stop persisting the file.


 > Note: One last warning of shade plugin during build: `[WARNING] 6 problems were encountered while building the effective model for org.openjfx:javafx-controls:jar:21 during dependency collection step for project (use -X to see details)` is related to JavaFX release 21. Warning will disappear with upgrade to version 24. Not included in this PR, as version upgrade is a separate issue #12 